### PR TITLE
CEV-6614

### DIFF
--- a/src/main/resources/project/config/createcfg.pl
+++ b/src/main/resources/project/config/createcfg.pl
@@ -50,18 +50,11 @@ if ( defined $property && "$property" ne "" ) {
 
 my $cfg =
   new ElectricCommander::PropDB( $ec, "/myProject/openstack_cfgs" );
-
-# set configuration description
-$cfg->setRow("$opts->{config}", "$opts->{description}");
   
 # add all the options as properties
 foreach my $key ( keys %{$opts} ) {
     
     if ( "$key" eq "config" ) {
-        next;
-    }
-
-	if ( "$key" eq "description" ) {
         next;
     }
 	

--- a/src/main/resources/project/project.xml
+++ b/src/main/resources/project/project.xml
@@ -474,7 +474,7 @@
                 <type>entry</type>
             </formalParameter>
             <formalParameter>
-                <formalParameterName>description</formalParameterName>
+                <formalParameterName>desc</formalParameterName>
                 <defaultValue/>
                 <description>A brief description of this configuration.</description>
                 <required>0</required>

--- a/src/main/resources/project/ui_forms/createConfigForm.xml
+++ b/src/main/resources/project/ui_forms/createConfigForm.xml
@@ -10,7 +10,7 @@
     <formElement>
         <type>entry</type>
         <label>Description:</label>
-        <property>description</property>
+        <property>desc</property>
         <value>OpenStack configuration</value>
         <documentation>Provide a simple description for this configuration.</documentation>
     </formElement>

--- a/src/main/resources/project/ui_forms/editConfigForm.xml
+++ b/src/main/resources/project/ui_forms/editConfigForm.xml
@@ -2,7 +2,7 @@
     <formElement>
         <type>entry</type>
         <label>Description:</label>
-        <property>description</property>
+        <property>desc</property>
         <documentation>Provide a simple description for this configuration.</documentation>
     </formElement>
     <formElement>


### PR DESCRIPTION
CEV-6614: When user make changes at the resource template and save
it,then run application will be completed with error because password
will be overlapped
- Make EC-OpenStack conform to how EC-EC2 stores the description field.
  This involved renaming the formalParameter to the createConfiguration
  procedure from 'description' -> 'desc' and adjusting associated .xml and
  .cgi files.
