### PR TITLE
ECPREOPSTK-105-Validation script for CreateConfiguration procedure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,9 @@ repositories {
 
 group = "com.electriccloud"
 description = "Plugins : EC-OpenStack"
-version = "1.2.1"
+version = "1.3.0"
 
+apply plugin: 'groovy'
 apply plugin: 'flow-gradle-plugin'
 
 
@@ -37,6 +38,7 @@ dependencies {
 	testCompile 'org.pacesys:openstack4j:2.0.3'
 	testCompile group: "net.schmizz", name: "sshj", version: "0.8.1"
 	testCompile group: "org.bouncycastle", name: "bcprov-jdk16", version: "1.46"
+    testCompile "org.codehaus.groovy:groovy-all:2.3.8"
 }
 
 test {

--- a/ecplugin_test.properties
+++ b/ecplugin_test.properties
@@ -9,6 +9,8 @@ blockstorage_service_url=<blockstorage_service_url>
 image_service_url=<image_service_url>
 orchestration_service_url=<orchestration_service_url>
 
+#E.g., file:///C:/EC/nimbus-main/nimbus/commander/commander-api/target/commander-api-6.0.0-SNAPSHOT.jar
+server_jar_urls=<jars_required_for_validation_script>
 ###### Block storage properties ######
 
 volume_type=<volume_type>

--- a/pages/EC-OpenStack_help.xml
+++ b/pages/EC-OpenStack_help.xml
@@ -1804,6 +1804,11 @@ outline used above where possible.
 
 
     <h1 id="rns">Release Notes</h1>
+    <h2>@PLUGIN_KEY@ 1.3.0</h2>
+    <ul>
+      <li>Added validation for CreateConfiguration procedure for use with the dynamic environments feature.</li>
+      <li>Added Tenant ID parameter to the plugin configuration.</li>
+    </ul>
     <h2>@PLUGIN_KEY@ 1.2.1</h2>
     <ul>
       <li>Fixed issue when resource wasn't created after provision with an error: "Duplicate resource name".</li>
@@ -1819,12 +1824,12 @@ outline used above where possible.
       <li>DeleteVolume to delete a volume from an OpenStack block storage.</li>
       <li>CreateImage to create a virtual machine (VM) image on OpenStack Image Service Glance.</li>
       <li>CreateInstanceSnapshot to create a snapshot of a server instance.</li>
-      <li>CreateVolumeSnapshot to create a snaphshot of a volume.</li>
+      <li>CreateVolumeSnapshot to create a snapshot of a volume.</li>
       <li>CreateStack to create a HEAT stack from a HEAT template.</li>
       <li>UpdateStack to update an existing stack with a template.</li>
       <li>DeleteStack to delete an existing stack.</li>
     </ul>
-    <p>The Deploy procuedure was updated to add support for customization scripts, availability zones, security groups, 
+    <p>The Deploy procedure was updated to add support for customization scripts, availability zones, security groups,
 			and deployments using an instance snapshot.</p>
       
 			

--- a/src/main/resources/project/manifest.xml
+++ b/src/main/resources/project/manifest.xml
@@ -234,4 +234,8 @@
         <path>procedures/delete_stack.pl</path>
         <xpath>//step[stepName=&quot;DeleteStack&quot;]/command</xpath>
     </file>
+    <file>
+        <path>procedures/form_scripts/validation/createConfiguration.groovy</path>
+        <xpath>//procedure[procedureName=&quot;CreateConfiguration&quot;]/propertySheet/property[propertyName=&quot;form&quot;]/propertySheet/property[propertyName=&quot;validation&quot;]/propertySheet/property[propertyName=&quot;script&quot;]/value</xpath>
+    </file>
 </fileset>

--- a/src/main/resources/project/procedures/form_scripts/validation/createConfiguration.groovy
+++ b/src/main/resources/project/procedures/form_scripts/validation/createConfiguration.groovy
@@ -1,0 +1,452 @@
+package ecplugins.openstack.scripts
+
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+import groovy.transform.Field
+import org.apache.http.HttpEntity
+import org.apache.http.HttpResponse
+import org.apache.http.client.ClientProtocolException
+import org.apache.http.conn.HttpHostConnectException
+import org.apache.http.conn.scheme.PlainSocketFactory
+
+import java.security.SecureRandom
+import java.security.cert.X509Certificate
+
+import javax.net.ssl.SSLContext
+import javax.net.ssl.TrustManager
+import javax.net.ssl.X509TrustManager
+
+import org.apache.http.HttpRequest
+import org.apache.http.client.HttpClient
+import org.apache.http.client.methods.HttpGet
+import org.apache.http.client.methods.HttpPost
+import org.apache.http.conn.scheme.Scheme
+import org.apache.http.conn.scheme.SchemeRegistry
+import org.apache.http.conn.ssl.SSLSocketFactory
+import org.apache.http.entity.StringEntity
+import org.apache.http.impl.client.DefaultHttpClient
+import org.apache.http.impl.conn.SingleClientConnManager
+
+import com.electriccloud.domain.FormalParameterValidationResult
+
+/**
+ * This script validates the OpenStack settings provided to the
+ * Create/Edit configuration. It takes the same input parameters as the
+ * CreateConfiguration procedure and authenticates the user with the
+ * given credentials against the OpenStack Identity service URL.
+ * Input parameter: {
+ *   "parameters" : {
+ *      "keystone_api_version" : "<3|2.0>",
+ *      "identity_service_url" : "e.g, https://<server>:<port>",
+ *      // credential details
+ *                  "userName" : "<username>",
+ *                  "password" : "<pwd>"
+ *   },
+ * }
+ * Output: {
+ *   "outcome" : "success|error"
+ *   If error then
+ *   "messages" : [
+ *                  {
+ *                    parameterName : 'param1',
+ *                          message : 'error message1'
+ *                  }, {
+ *                    parameterName : 'param2',
+ *                          message : 'error message2'
+ *                  }
+ *               ]
+ *   }
+ * }
+ */
+@Field
+final String USER_NAME = "userName"
+@Field
+final String PASSWORD = "password"
+@Field
+final String IDENTITY_SERVICE_URL = "identity_service_url"
+@Field
+final String IDENTITY_API_VERSION = "keystone_api_version"
+@Field
+final String TENANT_ID = "tenant_id"
+@Field
+final String COMPUTE_SERVICE_URL = "compute_service_url"
+@Field
+final String BLOCK_STORAGE_URL = "blockstorage_service_url"
+@Field
+final String IMAGE_SERVICE_URL = "image_service_url"
+@Field
+final String ORCHESTRATION_SERVICE_URL = "orchestration_service_url"
+
+
+// Main driver
+if (canValidate(args)) {
+    doValidations(args)
+} else {
+    // simply return success if cannot do validations
+    // yet on the given input
+    FormalParameterValidationResult.SUCCESS
+}
+
+//--------------------Helper classes and functions-----------------------------//
+public class InvalidParameterException extends IllegalArgumentException {
+    String parameter
+    InvalidParameterException(String parameter, String message) {
+        super(message)
+        this.parameter = parameter
+    }
+}
+
+boolean canValidate(args) {
+    hasValue(args, USER_NAME) &&
+        hasValue(args, PASSWORD) &&
+        hasValue(args, IDENTITY_SERVICE_URL) &&
+        hasValue(args, IDENTITY_API_VERSION)
+}
+
+def doValidations(args) {
+
+    def result
+    try {
+
+        // Start with authentication
+
+        // Make sure we are ready to authenticate with openstack
+        // this method will throw exceptions to bail out
+        preAuthentication(args)
+
+        // build payload for authentication
+        def jsonPayload = buildAuthenticationPayload(args)
+        HttpEntity payload = new StringEntity(JsonOutput.toJson(jsonPayload))
+        payload.setContentType("application/json")
+
+        String url = buildIdentityServiceURL(args)
+
+        def response = doPost(url, payload)
+
+        def statusCode = response.statusLine.statusCode
+        if (statusCode < 400) {
+            result = validateResponse(args, response.jsonResponse)
+        } else if (statusCode == 401) {
+            result = buildAuthenticationError(args)
+        } else {
+            result = buildErrorResponse(IDENTITY_SERVICE_URL, statusCode + ":" + response.statusLine.reasonPhrase)
+        }
+
+    } catch (InvalidParameterException ex) {
+        result = buildErrorResponse(ex.parameter, ex.message)
+    } catch (HttpHostConnectException|
+             ClientProtocolException |
+             IllegalStateException |
+             UnknownHostException ex) {
+        result = buildErrorResponse('identity_service_url', 'Identity Service URL is invalid')
+    } catch (Exception ex) {
+        //catch-all for any other unknown exceptions encountered during validation
+        result = buildErrorResponse(IDENTITY_SERVICE_URL, ex)
+    }
+
+    result
+}
+
+void preAuthentication(args) {
+
+    def apiVersion = args.parameters[IDENTITY_API_VERSION]
+    if (apiVersion != "2.0" && apiVersion != "3") {
+        throw new InvalidParameterException(IDENTITY_API_VERSION,
+                apiVersion + " not supported as Keystone API Version value. " +
+                "Supported values are '2.0' and '3'")
+    }
+
+}
+
+def doPost(String url, HttpEntity payload) {
+    HttpClient httpClient
+    try {
+        def httpRequest = createRequest(url, "post", payload)
+        httpClient = buildMostTrustingHttpClient(httpRequest)
+        HttpResponse response = httpClient.execute(httpRequest)
+
+        // read the response only upon success
+        def jsonResponse = null
+        if (response.statusLine.statusCode < 400) {
+            jsonResponse = readResponse(response.entity)
+        }
+
+        def result = [:]
+        result.statusLine = response.statusLine
+        result.jsonResponse = jsonResponse
+
+        return result
+    } finally {
+        if (httpClient != null) httpClient.getConnectionManager().shutdown()
+    }
+}
+
+boolean hasValue(args, parameter) {
+    args.parameters && args.parameters[parameter] != null && args.parameters[parameter] != ""
+}
+
+String buildIdentityServiceURL(args) {
+
+    def identityServiceUrl = args.parameters[IDENTITY_SERVICE_URL]
+    def keystoneAPIVersion = args.parameters[IDENTITY_API_VERSION]
+
+    identityServiceUrl += "/v" + keystoneAPIVersion
+    if (keystoneAPIVersion == "2.0") {
+        identityServiceUrl += "/tokens"
+    } else{
+        identityServiceUrl += "/auth/tokens"
+    }
+    identityServiceUrl
+}
+
+def buildAuthenticationPayload(args) {
+    def jsonPayload = [:]
+    def keystoneAPIVersion = args.parameters.keystone_api_version
+    if (keystoneAPIVersion == "2.0") {
+        jsonPayload."auth" = [:]
+        jsonPayload."auth"."tenantId" = hasValue(args, TENANT_ID) ? args.parameters[TENANT_ID] : ""
+        jsonPayload."auth"."passwordCredentials" = [:]
+        jsonPayload."auth"."passwordCredentials"."username" = args.parameters.userName
+        jsonPayload."auth"."passwordCredentials"."password" = args.parameters.password
+    } else {
+        jsonPayload."auth" = [:]
+        jsonPayload."auth"."identity" = [:]
+        jsonPayload."auth"."identity"."methods" = ["password"]
+        jsonPayload."auth"."identity"."password" = [:]
+        jsonPayload."auth"."identity"."password"."user" = [:]
+        jsonPayload."auth"."identity"."password"."user"."name" = args.parameters.userName
+        jsonPayload."auth"."identity"."password"."user"."password" = args.parameters.password
+        jsonPayload."auth"."identity"."password"."user"."domain" = [:]
+        jsonPayload."auth"."identity"."password"."user"."domain"."id" = "default"
+
+        if (hasValue(args, TENANT_ID)) {
+            jsonPayload."auth"."scope" = [:]
+            jsonPayload."auth"."scope"."project" = [:]
+            jsonPayload."auth"."scope"."project"."id" = args.parameters[TENANT_ID]
+        }
+    }
+    jsonPayload
+}
+
+/**
+ * Simple helper method to construct the HttpRequest using the given
+ * <code>url</code>, <code>httpMethod</code> handling "get" or "post"
+ * for now, and the <code>payload</code>.
+ */
+HttpRequest createRequest(String url, String httpMethod, StringEntity payload) {
+
+    def httpRequest
+    switch (httpMethod) {
+        case "post":
+            httpRequest = new HttpPost(url)
+            httpRequest.setEntity(payload)
+            break
+        case "get"://fall thru to default
+        default:
+            httpRequest = new HttpGet(url)
+            break
+    }
+    httpRequest
+}
+
+/**
+ * Like the name suggests, this is the most trusting http client since
+ * it establishes a trust manager that trusts everything disregarding
+ * presence or absence of any certificate from the server the client
+ * tries to connect with using SSL. This is really a hack for
+ * SSLPeerUnverifiedException when connecting to OpenStack using
+ * Apache HttpClient. Its possible there is an untrusted certificate
+ * in the chain which this hack ignores to go through with the connection.
+ */
+HttpClient buildMostTrustingHttpClient (HttpRequest httpRequest) {
+    //Set up a TrustManager that trusts everything
+    SSLContext sslContext = SSLContext.getInstance("SSL")
+    TrustManager[] trustManagers = [ new X509TrustManager() {
+        public X509Certificate[] getAcceptedIssuers() {
+            return null
+        }
+
+        public void checkClientTrusted(X509Certificate[] certs,
+                                       String authType) {}
+
+        public void checkServerTrusted(X509Certificate[] certs,
+                                       String authType) {}
+    } ]
+
+    sslContext.init(null, trustManagers, new SecureRandom())
+    SSLSocketFactory sslFactory = new SSLSocketFactory(sslContext,
+            SSLSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER)
+
+    SchemeRegistry schemeRegistry = new SchemeRegistry()
+    schemeRegistry.register(new Scheme("https", 443, sslFactory))
+    schemeRegistry.register( new Scheme("http", 80, PlainSocketFactory.getSocketFactory()))
+
+    SingleClientConnManager cm = new SingleClientConnManager(
+            httpRequest.getParams(), schemeRegistry)
+    return new DefaultHttpClient(cm, httpRequest.getParams())
+}
+
+
+/**
+ * Helper method to parse the server JSON response into
+ * a basic object instance.
+ */
+def readResponse(def entity) {
+
+    int bytesRead
+    def result = new String()
+    byte[] buffer = new byte[1024]
+    InputStream inputStream = entity.getContent()
+    def bis = new BufferedInputStream(inputStream)
+    while ((bytesRead = bis.read(buffer)) != -1) {
+        String chunk = new String(buffer, 0, bytesRead)
+        chunk.toLowerCase()
+        result += chunk
+    }
+    (new JsonSlurper()).parseText(result)
+}
+
+/**
+ * Construct and returns an error response object using the given
+ * exception. All the relevant details from the exception may be
+ * extracted out here such as the exception stack trace. For now,
+ * only retrieving the exception class and message.
+ */
+def buildErrorResponse(String parameter, Exception ex) {
+    buildErrorResponse(parameter, ex.getClass().getName() + ":" + ex.getMessage())
+}
+
+/**
+ * Constructs and returns an error response object using the given
+ * <code>errorMessage</code>
+ */
+def buildErrorResponse(String parameter, String errorMessage) {
+    def errors = FormalParameterValidationResult.errorResult()
+    errors.error(parameter, errorMessage)
+}
+
+def buildAuthenticationError(args) {
+    def tenantIdProvided = hasValue(args, TENANT_ID)
+    def error = tenantIdProvided ?
+            'Invalid username and password for tenant' :
+            'Invalid username and password'
+
+    result = buildErrorResponse(USER_NAME, error).
+            error(PASSWORD, error)
+    if (tenantIdProvided) {
+        result.error(TENANT_ID, error)
+    }
+    result
+}
+
+def validateResponse(args, jsonResponse) {
+    def result
+    if (hasValue(args, TENANT_ID)) {
+        //If the tenant id was provided, then OpenStack API returns the service catalog information
+        // for the tenant (project) that can be used to then validate the other API urls.
+        result = validateServiceURLs(args, jsonResponse)
+    }
+    if (result == null) result = FormalParameterValidationResult.SUCCESS
+
+    result
+}
+
+private def validateServiceURLs(args, jsonResponse) {
+    def result
+    def list = []
+    validateServiceURL(args, jsonResponse, COMPUTE_SERVICE_URL, 'Compute Service URL', 'compute', list)
+    validateServiceURL(args, jsonResponse, BLOCK_STORAGE_URL, 'Block Storage URL', 'volume', list)
+    validateServiceURL(args, jsonResponse, IMAGE_SERVICE_URL, 'Image Service URL', 'image', list)
+    validateServiceURL(args, jsonResponse, ORCHESTRATION_SERVICE_URL, 'Orchestration Service URL', 'orchestration', list)
+    if (list.size() > 0) {
+        result = FormalParameterValidationResult.errorResult()
+        for (def err : list) {
+            result.error(err.param, err.message)
+        }
+    }
+    result
+}
+
+private def validateServiceURL(args, jsonResponse,
+                               String serviceUrlParam,
+                               String urlLabel,
+                               String serviceType,
+                               List list) {
+
+    if (!hasValue(args, serviceUrlParam)) {
+        return
+    }
+
+    def endPoints
+    def apiVersion = args.parameters[IDENTITY_API_VERSION]
+
+    if (apiVersion == "2.0") {
+        def catalogItem = jsonResponse.access.serviceCatalog.find{ node->
+            node["type"] == serviceType
+        }
+
+        if (catalogItem != null && catalogItem.size() > 0) {
+            endPoints = catalogItem.endpoints.publicURL
+        }
+
+    } else { //assuming version 3
+        def catalogItem = jsonResponse.token.catalog.find{ node->
+            node["type"] == serviceType
+        }
+
+        if (catalogItem != null && catalogItem.size() > 0) {
+            endPoints = catalogItem.endpoints.url
+        }
+    }
+
+    if (endPoints != null && endPoints.size() > 0) {
+        def inputUrl = args.parameters[serviceUrlParam]
+        for (String endPoint : endPoints) {
+            endPoint =
+                    stripTenantIdAndVersionFromUrl(endPoints[0],
+                            args.parameters[TENANT_ID])
+
+            if (endPoint == inputUrl) {
+                // found
+                return
+            }
+        }
+        // input service url is not valid
+        def endPoint =
+                stripTenantIdAndVersionFromUrl(endPoints[0],
+                                               args.parameters[TENANT_ID])
+        def error = [:]
+        error.param = serviceUrlParam
+        error.message = "${urlLabel} is invalid. Enter valid URL: '${endPoint}'."
+        list.add(error)
+    } else {
+        def error = [:]
+        error.param = serviceUrlParam
+        error.message = "No ${urlLabel} is supported by this OpenStack deployment."
+        list.add(error)
+    }
+
+}
+
+String stripTenantIdAndVersionFromUrl(String endPoint, String tenantId) {
+
+    // remove any trailing / in the url
+    if (endPoint.endsWith("/")) {
+        endPoint = endPoint.substring(0, endPoint.length() - 1)
+    }
+
+    //remove tenantId if present
+    if (endPoint.endsWith("/${tenantId}")) {
+        endPoint = endPoint.substring(0, endPoint.length() - (tenantId.length() + 1))
+    }
+
+    //finally remove any version string
+    // version string can be of different forms, e.g., v3, v2.0,
+    // so, we check for any trailing '/vd+(.d+)*'
+    def match = endPoint =~ '(.*)/v\\d+(.\\d+)*'
+    if (match.find()) {
+        endPoint = match.group(1)
+    }
+
+    endPoint
+}

--- a/src/main/resources/project/project.xml
+++ b/src/main/resources/project/project.xml
@@ -403,6 +403,16 @@
                                     </propertySheet>
                                 </property>
                                 <property>
+                                    <propertyName>tenant_id</propertyName>
+                                    <propertySheet>
+                                        <property>
+                                            <propertyName>formType</propertyName>
+                                            <expandable>1</expandable>
+                                            <value>standard</value>
+                                        </property>
+                                    </propertySheet>
+                                </property>
+                                <property>
                                     <propertyName>orchestration_service_url</propertyName>
                                     <propertySheet>
                                         <property>
@@ -450,6 +460,23 @@
                     <expandable>0</expandable>
                     <value/>
                 </property>
+                <!--Form scripts for validation and dynamic options-->
+                <property>
+                    <propertyName>form</propertyName>
+                    <propertySheet>
+                        <property>
+                            <propertyName>validation</propertyName>
+                            <propertySheet>
+                                <property>
+                                    <propertyName>script</propertyName>
+                                    <expandable>1</expandable>
+                                    <value/>
+                                </property>
+                            </propertySheet>
+                        </property>
+                    </propertySheet>
+                </property>
+                <!--End-of Form scripts for validation and dynamic options-->
             </propertySheet>
             <formalParameter>
                 <formalParameterName>config</formalParameterName>
@@ -555,6 +582,15 @@
                 <description>The host name or IP address of the Orchestration Service for OpenStack</description>
                 <expansionDeferred>0</expansionDeferred>
                 <required>1</required>
+                <type>entry</type>
+            </formalParameter>
+
+            <formalParameter>
+                <formalParameterName>tenant_id</formalParameterName>
+                <defaultValue/>
+                <description>ID of the OpenStack tenant to use</description>
+                <expansionDeferred>0</expansionDeferred>
+                <required>0</required>
                 <type>entry</type>
             </formalParameter>
 

--- a/src/main/resources/project/ui_forms/createConfigForm.xml
+++ b/src/main/resources/project/ui_forms/createConfigForm.xml
@@ -19,15 +19,32 @@
         <label>Identity Service URL:</label>
         <property>identity_service_url</property>
         <value></value>
+        <serverValidation>1</serverValidation>
         <documentation>Provide the host name or IP address of the Identity Service for OpenStack.For example, http://192.168.100.134:8776. Do not include API version or tenant ID in URL here.</documentation>
         <required>1</required>
     </formElement>
-
+    <formElement>
+        <type>credential</type>
+        <label>Login as:</label>
+        <property>credential</property>
+        <required>1</required>
+        <serverValidation>1</serverValidation>
+        <documentation>OpenStack account username/password. This account must have enough privileges to perform API functions.</documentation>
+    </formElement>
+    <formElement>
+        <label>Tenant ID:</label>
+        <property>tenant_id</property>
+        <documentation>ID of the OpenStack tenant to use.</documentation>
+        <required>0</required>
+        <serverValidation>1</serverValidation>
+        <type>entry</type>
+    </formElement>
     <formElement>
         <type>entry</type>
         <label>Compute Service URL:</label>
         <property>compute_service_url</property>
         <value></value>
+        <serverValidation>1</serverValidation>
         <documentation>Provide the host name or IP address of the Compute Service for OpenStack.For example, http://192.168.100.134:8776. Do not include API version or tenant ID in URL here.</documentation>
         <required>1</required>
     </formElement>
@@ -36,6 +53,7 @@
         <label>Block Storage URL:</label>
         <property>blockstorage_service_url</property>
         <value></value>
+        <serverValidation>1</serverValidation>
         <documentation>Provide the host name or IP address of the Block Storage Service for OpenStack.For example, http://192.168.100.134:8776. Do not include API version or tenant ID in URL here.</documentation>
         <required>1</required>
     </formElement>
@@ -44,6 +62,7 @@
         <label>Image Service URL:</label>
         <property>image_service_url</property>
         <value></value>
+        <serverValidation>1</serverValidation>
         <documentation>Provide the host name or IP address of the Image Service for OpenStack.For example, http://192.168.100.134:8776. Do not include API version or tenant ID in URL here.</documentation>
         <required>1</required>
     </formElement>
@@ -52,15 +71,9 @@
         <label>Orchestration Service URL:</label>
         <property>orchestration_service_url</property>
         <value></value>
+        <serverValidation>1</serverValidation>
         <documentation>Provide the host name or IP address of the Orchestration Service for OpenStack.For example, http://192.168.100.134:8776. Do not include API version or tenant ID in URL here.</documentation>
         <required>0</required>
-    </formElement>
-    <formElement>
-        <type>credential</type>
-        <label>Login as:</label>
-        <property>credential</property>
-        <required>1</required>
-        <documentation>OpenStack account username/password. This account must have enough privileges to perform API functions.</documentation>
     </formElement>
     <formElement>
         <type>entry</type>

--- a/src/main/resources/project/ui_forms/editConfigForm.xml
+++ b/src/main/resources/project/ui_forms/editConfigForm.xml
@@ -14,6 +14,20 @@
         <required>1</required>
     </formElement>
     <formElement>
+        <type>credential</type>
+        <label>Login as:</label>
+        <property>credential</property>
+        <required>1</required>
+        <documentation>OpenStack account username/password. This account must have enough privileges to perform API functions.</documentation>
+    </formElement>
+    <formElement>
+        <label>Tenant ID:</label>
+        <property>tenant_id</property>
+        <documentation>ID of the OpenStack tenant to use.</documentation>
+        <required>0</required>
+        <type>entry</type>
+    </formElement>
+    <formElement>
         <type>entry</type>
         <label>Keystone API version</label>
         <property>keystone_api_version</property>
@@ -77,15 +91,6 @@
         <documentation>Provide the host name or IP address of the Orchestration Service for OpenStack.For example, http://192.168.100.134:8776. Do not include API version or tenant ID in URL here.</documentation>
         <required>0</required>
     </formElement>
-    <formElement>
-        <type>credential</type>
-        <label>Login as:</label>
-        <property>credential</property>
-        <required>1</required>
-        <documentation>OpenStack account username/password. This account must have enough privileges to perform API functions.</documentation>
-    </formElement>
-
-
     <formElement>
         <type>entry</type>
         <label>Resource:</label>

--- a/src/test/groovy/CreateConfigurationValidationTest.groovy
+++ b/src/test/groovy/CreateConfigurationValidationTest.groovy
@@ -1,0 +1,332 @@
+import groovy.json.JsonBuilder
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+
+class CreateConfigurationValidationTest extends GroovyShellTestCase {
+
+    ResourceBundle testProperties;
+
+    // test constants
+    def USER = System.getProperty("OPENSTACK_USER");
+    def PASSWORD = System.getProperty("OPENSTACK_PASSWORD");
+    def TENANT_ID = System.getProperty("OPENSTACK_TENANTID");
+
+    //properties in the test property file
+    def PROP_IDENTITY_URL = 'identity_service_url'
+    def PROP_SCRIPT_JAR_URLS = 'server_jar_urls'
+
+    @Override
+    void setUp() {
+        super.setUp()
+
+        testProperties =
+                new PropertyResourceBundle(new FileInputStream("ecplugin_test.properties"))
+        for (String url: testProperties.getString(PROP_SCRIPT_JAR_URLS).split(',')) {
+            Thread.currentThread().getContextClassLoader().addURL(new URL(url))
+        }
+    }
+
+    void testInputParameterValidations() {
+
+        def json = new JsonBuilder()
+        def actualParams = json (
+                userName : ''
+        )
+        def input = json (
+                parameters : actualParams
+        )
+
+        checkSuccessResponse({})
+
+        checkSuccessResponse(input)
+
+        actualParams = json (
+                userName : USER
+        )
+        input = json (
+                parameters : actualParams
+        )
+
+        checkSuccessResponse(input)
+
+        actualParams = json (
+                userName: USER,
+                password: PASSWORD,
+                test: "value"
+        )
+        def inputWithValidCreds = json (
+                parameters : actualParams
+        )
+
+        checkSuccessResponse(input)
+
+        actualParams = json (
+                userName: USER,
+                password: PASSWORD,
+                identity_service_url : testProperties.getString(PROP_IDENTITY_URL)
+            )
+
+        inputWithValidCreds.parameters = actualParams
+        checkSuccessResponse(inputWithValidCreds)
+
+        actualParams = json (
+                userName: USER,
+                password: PASSWORD,
+                identity_service_url : testProperties.getString(PROP_IDENTITY_URL),
+                keystone_api_version: '5'
+        )
+        inputWithValidCreds.parameters = actualParams
+        checkErrorResponse(inputWithValidCreds, 'keystone_api_version', "5 not supported as Keystone API Version value. Supported values are '2.0' and '3'")
+
+    }
+
+    void testInvalidIdentityUrl() {
+        checkInvalidIdentityUrl("2.0")
+        checkInvalidIdentityUrl("3")
+    }
+
+    void testInvalidUserId() {
+        checkInvalidUserId("2.0")
+        checkInvalidUserId("3")
+    }
+
+    void testInvalidPassword() {
+        checkInvalidPassword("2.0")
+        checkInvalidPassword("3")
+    }
+
+    void testInvalidTenantId() {
+        checkInvalidTenantId("2.0")
+        checkInvalidTenantId("3")
+    }
+
+    void testValidConfiguration() {
+        checkValidConfiguration("3")
+        checkValidConfiguration("2.0")
+    }
+
+    void testValidConfigurationWithTenant() {
+        checkValidConfiguration("3", TENANT_ID)
+        checkValidConfiguration("2.0", TENANT_ID)
+    }
+
+    void testInvalidServiceUrls() {
+        checkInvalidServiceUrl("3", "compute_service_url", "Compute Service URL", "https://region-b.geo-1.compute.hpcloudsvc.com")
+        checkInvalidServiceUrl("2.0", "compute_service_url", "Compute Service URL", "https://region-b.geo-1.compute.hpcloudsvc.com")
+
+        checkInvalidServiceUrl("3", "blockstorage_service_url", "Block Storage URL", "https://region-b.geo-1.block.hpcloudsvc.com")
+        checkInvalidServiceUrl("2.0", "blockstorage_service_url", "Block Storage URL", "https://region-b.geo-1.block.hpcloudsvc.com")
+
+        checkInvalidServiceUrl("3", "image_service_url", "Image Service URL", "https://region-b.geo-1.images.hpcloudsvc.com:443")
+        checkInvalidServiceUrl("2.0", "image_service_url", "Image Service URL", "https://region-b.geo-1.images.hpcloudsvc.com:443")
+
+        checkUnsupportedServiceUrl("3", "orchestration_service_url", "Orchestration Service URL")
+        checkUnsupportedServiceUrl("2.0", "orchestration_service_url", "Orchestration Service URL")
+    }
+
+    void testValidServiceUrls() {
+        checkValidServiceUrls("3")
+        checkValidServiceUrls("2.0")
+    }
+
+    void checkUnsupportedServiceUrl(def version, def service, def serviceUrlLabel) {
+        def json = new JsonBuilder()
+
+        def actualParams = json (
+                userName : USER,
+                password : PASSWORD,
+                identity_service_url : testProperties.getString(PROP_IDENTITY_URL),
+                keystone_api_version: version,
+                tenant_id: TENANT_ID
+        )
+        actualParams[service] = 'http://some_invalid_service'
+
+        def input = json (
+                parameters : actualParams
+        )
+        checkErrorResponse(input, service, "No ${serviceUrlLabel} is supported by this OpenStack deployment.")
+    }
+
+    void checkInvalidServiceUrl(def version, def service, def serviceUrlLabel, def expectedServiceUrl) {
+        def json = new JsonBuilder()
+
+        def actualParams = json (
+                userName : USER,
+                password : PASSWORD,
+                identity_service_url : testProperties.getString(PROP_IDENTITY_URL),
+                keystone_api_version: version,
+                tenant_id: TENANT_ID
+        )
+        actualParams[service] = 'http://some_invalid_service'
+
+        def input = json (
+                parameters : actualParams
+        )
+        checkErrorResponse(input, service, "${serviceUrlLabel} is invalid. Enter valid URL: '${expectedServiceUrl}'.")
+    }
+
+    void checkValidServiceUrls(def version) {
+
+        def json = new JsonBuilder()
+
+        def actualParams = json (
+                userName : USER,
+                password : PASSWORD,
+                identity_service_url : testProperties.getString(PROP_IDENTITY_URL),
+                keystone_api_version: version,
+                tenant_id: TENANT_ID,
+                compute_service_url: "https://region-b.geo-1.compute.hpcloudsvc.com",
+                blockstorage_service_url: "https://region-b.geo-1.block.hpcloudsvc.com",
+                image_service_url: "https://region-b.geo-1.images.hpcloudsvc.com:443"
+        )
+        def input = json (
+                parameters : actualParams
+        )
+
+        checkSuccessResponse(input)
+
+    }
+
+    void checkValidConfiguration(def version, def tenantId) {
+
+        def json = new JsonBuilder()
+
+        def actualParams = json (
+                userName : USER,
+                password : PASSWORD,
+                identity_service_url : testProperties.getString(PROP_IDENTITY_URL),
+                keystone_api_version: version,
+                tenant_id: tenantId
+        )
+        def input = json (
+                parameters : actualParams
+        )
+
+        checkSuccessResponse(input)
+
+    }
+
+    void checkValidConfiguration(def version) {
+
+        checkValidConfiguration(version, /*tenant*/ null)
+
+    }
+
+    void checkInvalidIdentityUrl(def version) {
+
+        def json = new JsonBuilder()
+
+        def actualParams = json (
+                userName : USER,
+                password : PASSWORD,
+                identity_service_url : 'https://invalidserver.hpcloudsvc.com:35357',
+                keystone_api_version : version
+            )
+        def input = json (
+                parameters : actualParams
+        )
+
+        checkErrorResponse(input, 'identity_service_url', "Identity Service URL is invalid")
+
+    }
+
+    void checkInvalidUserId(def version) {
+
+        def json = new JsonBuilder()
+
+        def actualParams = json (
+                userName : 'dummyuser123',
+                password : PASSWORD,
+                identity_service_url : testProperties.getString(PROP_IDENTITY_URL),
+                keystone_api_version: version
+            )
+
+        def input = json (
+                parameters : actualParams
+        )
+
+        checkErrorResponse(input, 'userName', "Invalid username and password")
+
+    }
+
+    void checkInvalidTenantId(def version) {
+
+        def json = new JsonBuilder()
+
+        def actualParams = json (
+                userName : USER,
+                password : PASSWORD,
+                tenant_id: '0000000abc',
+                identity_service_url : testProperties.getString(PROP_IDENTITY_URL),
+                keystone_api_version: version
+        )
+
+        def input = json (
+                parameters : actualParams
+        )
+
+        checkErrorResponse(input, 'tenant_id', "Invalid username and password for tenant")
+
+    }
+
+    void checkInvalidPassword(def version) {
+
+        def json = new JsonBuilder()
+
+        def actualParams = json (
+                userName : USER,
+                password : 'asfasfdsfsfhr',
+                identity_service_url : testProperties.getString(PROP_IDENTITY_URL),
+                keystone_api_version: version
+            )
+        def input = json (
+                parameters : actualParams
+        )
+
+        //not passing any error message to validate for invalid password as the actual error message is
+        //unpredictable in this case. Sometimes the server returns 401:Unauthorized and other times
+        //it return 500: server error. As long as it returns an error, we are ok
+        checkErrorResponse(input, 'credential', null)
+
+    }
+
+    void checkSuccessResponse(def inputParam) {
+        def fileResource = this.class.classLoader.getResourceAsStream("project/procedures/form_scripts/validation/createConfiguration.groovy")
+        BufferedReader fileReader = new BufferedReader(new InputStreamReader(fileResource));
+        def json = JsonOutput.toJson(inputParam)
+        def args = new JsonSlurper().parseText(json)
+        def result = withBinding( [args: args] ) {
+            shell.evaluate(fileReader)
+        }
+        System.out.println("Response: " + JsonOutput.toJson(result))
+        assertEquals "success", result.outcome.toString()
+    }
+
+    void checkErrorResponse(def inputParam, def parameter, def expectedError) {
+        def fileResource = this.class.classLoader.getResourceAsStream("project/procedures/form_scripts/validation/createConfiguration.groovy")
+        BufferedReader fileReader = new BufferedReader(new InputStreamReader(fileResource));
+        def json = JsonOutput.toJson(inputParam)
+        def args = new JsonSlurper().parseText(json)
+        def result = withBinding( [args: args] ) {
+            shell.evaluate(fileReader)
+        }
+        assertEquals "error", result.outcome.toString()
+        if (expectedError != null) {
+            def errMsg = findErrorMessage(result.messages, parameter)
+            assertEquals "Incorrect error message with input parameters: " + json, parameter, errMsg.parameterName
+            assertEquals "Incorrect error message with input parameters: " + json, expectedError, errMsg.message
+        }
+
+    }
+
+    def findErrorMessage(def messages, def parameter) {
+        for (message in messages) {
+            if (message.parameterName.equals(parameter)) {
+                return message
+            }
+        }
+        // fail if we did not find the message yet
+        fail('Error message not found for parameter: ' + parameter +
+                ', in error messages: \n' + JsonOutput.toJson(messages))
+    }
+}

--- a/src/test/java/ecplugins/openstack/OpenStackProvisionTest.java
+++ b/src/test/java/ecplugins/openstack/OpenStackProvisionTest.java
@@ -28,6 +28,8 @@ import org.openstack4j.model.compute.*;
 import org.openstack4j.model.compute.Server;
 import org.openstack4j.model.compute.ServerCreate;
 import org.openstack4j.model.storage.block.Volume;
+
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
 import org.openstack4j.model.heat.Stack;
 import org.openstack4j.model.image.Image;
@@ -56,6 +58,7 @@ public class OpenStackProvisionTest {
     private final static String PASSWORD = System.getProperty("OPENSTACK_PASSWORD");
     private final static String TENANTID = System.getProperty("OPENSTACK_TENANTID");
     private final static String PLUGIN_VERSION = System.getProperty("PLUGIN_VERSION");
+    private final static String PARAM_TENANTID = "tenant_id";
     private final static String FLAVOR_ID = "flavor_id";
     private final static String IMAGE_ID = "image_id";
     private final static String KEY_NAME = "key_name";
@@ -179,10 +182,7 @@ public class OpenStackProvisionTest {
 
         String jobId = callRunProcedure(jo);
 
-        String response = waitForJob(jobId);
-
-        // Check job status
-        assertEquals("Job completed without errors", "success", response);
+        waitForJobToCompleteSuccessfully(jobId);
 
         // Get the key pair from OpenStack
         Keypair keypair = m_osClient.compute().keypairs().get(keyNameToCreate);
@@ -254,9 +254,7 @@ public class OpenStackProvisionTest {
 
             String jobId = callRunProcedure(jo);
 
-            String response = waitForJob(jobId);
-
-            assertEquals("Job completed with errors", "success", response);
+            waitForJobToCompleteSuccessfully(jobId);
 
             // Get the Volume from OpenStack
             listOfVolumes = m_osClient.blockStorage().volumes().list();
@@ -317,9 +315,8 @@ public class OpenStackProvisionTest {
 
             String jobId = callRunProcedure(jo);
 
-            String response = waitForJob(jobId);
+            waitForJobToCompleteSuccessfully(jobId);
 
-            assertEquals("Job completed with errors", "success", response);
             assertEquals("Volume size not extended.", "2", Integer.toString(m_osClient.blockStorage().volumes().get(volumeId).getSize()));
 
         } // end Scope : Extend Volume
@@ -389,9 +386,7 @@ public class OpenStackProvisionTest {
 
             String jobId = callRunProcedure(jo);
 
-            String response = waitForJob(jobId);
-
-            assertEquals("Job completed with errors", "success", response);
+            waitForJobToCompleteSuccessfully(jobId);
 
             // Assert volumeFromOpenstack is not null
             assertNotNull(volumeFromOpenstack);
@@ -442,10 +437,7 @@ public class OpenStackProvisionTest {
             System.out.println("Detaching [" + volumeNameToCreate + "] from server [TestServer].");
             String jobId = callRunProcedure(jo);
 
-            String response = waitForJob(jobId);
-
-            // Check job status
-            assertEquals("Job completed with errors", "success", response);
+            waitForJobToCompleteSuccessfully(jobId);
 
             // Verify that the volume is available indicating it is successfully detached.
             assertEquals("Volume status is not set correctly", "available", m_osClient.blockStorage().volumes().get(volumeId).getStatus().toString());
@@ -479,12 +471,8 @@ public class OpenStackProvisionTest {
             System.out.println("Deleting volume [" + volumeNameToCreate + "].");
             String jobId = callRunProcedure(jo);
 
-            String response = waitForJob(jobId);
+            waitForJobToCompleteSuccessfully(jobId);
 
-            // Check job status
-            assertEquals("Job completed with errors", "success", response);
-
-            volumeFromOpenstack = null;
             // Check for existance of volume
             volumeFromOpenstack = m_osClient.blockStorage().volumes().get(volumeId);
 
@@ -579,11 +567,7 @@ public class OpenStackProvisionTest {
 
             String jobId = callRunProcedure(jo);
 
-            String response = waitForJob(jobId);
-
-            // Check job status
-            assertEquals("Job completed without errors", "success", response);
-
+            waitForJobToCompleteSuccessfully(jobId);
 
             // Get the stack from OpenStack
             for (Stack stack : m_osClient.heat().stacks().list()) {
@@ -658,10 +642,7 @@ public class OpenStackProvisionTest {
             System.out.println("Updating stack to template : " + updatedTemplate);
             String jobId = callRunProcedure(jo);
 
-            String response = waitForJob(jobId);
-
-            // Check job status
-            assertEquals("Job completed without errors", "success", response);
+            waitForJobToCompleteSuccessfully(jobId);
 
             // Assert that after updation of stack , updated time is not null
             assertNotNull(m_osClient.heat().stacks().getDetails(stackNameToCreate, stackId).getUpdatedTime());
@@ -708,10 +689,7 @@ public class OpenStackProvisionTest {
             System.out.println("Deleting stack [" + stackNameToCreate + "].");
             String jobId = callRunProcedure(jo);
 
-            String response = waitForJob(jobId);
-
-            // Check job status
-            assertEquals("Job completed without errors", "success", response);
+            waitForJobToCompleteSuccessfully(jobId);
 
             // Assert that the stack with name "automatedTest-testStackCreation" no longer exists.
             stackFromOpenstack = null;
@@ -810,10 +788,7 @@ public class OpenStackProvisionTest {
         System.out.println("Creating image [" + imageNameToCreate + "].");
         String jobId = callRunProcedure(jo);
 
-        String response = waitForJob(jobId);
-
-        // Check job status
-        assertEquals("Job completed without errors", "success", response);
+        waitForJobToCompleteSuccessfully(jobId);
 
         // Get the keypair from OpenStack
         Image imageFromOpenstack = null;
@@ -915,10 +890,7 @@ public class OpenStackProvisionTest {
             System.out.println("Creating a snapshot [" + snapshotNameToCreate + " ] of instance [ TestServer ].");
             String jobId = callRunProcedure(jo);
 
-            String response = waitForJob(jobId);
-
-            // Check job status
-            assertEquals("Job completed without errors", "success", response);
+            waitForJobToCompleteSuccessfully(jobId);
 
             org.openstack4j.model.compute.Image instanceSnapshot = null;
             // Get the instance snapshot from OpenStack
@@ -1013,10 +985,7 @@ public class OpenStackProvisionTest {
             System.out.println("Deploying an instance [ " + instanceNameToCreate + " ] from a snapshot [" + snapshotNameToCreate + " ].");
             String jobId = callRunProcedure(jo);
 
-            String response = waitForJob(jobId);
-
-            // Check job status
-            assertEquals("Job completed without errors", "success", response);
+            waitForJobToCompleteSuccessfully(jobId);
 
             Server instanceFromOpenstack = null;
             // Get the instance from OpenStack
@@ -1088,10 +1057,7 @@ public class OpenStackProvisionTest {
             System.out.println("Rebooting instance [ " + instanceNameToCreate + " ].");
             String jobId = callRunProcedure(jo);
 
-            String response = waitForJob(jobId);
-
-            // Check job status
-            assertEquals("Job completed without errors", "success", response);
+            waitForJobToCompleteSuccessfully(jobId);
 
             // Assert that instance is now ACTIVE after reboot.
 
@@ -1150,7 +1116,7 @@ public class OpenStackProvisionTest {
      * @param jo
      * @return the jobId of the job launched by runProcedure
      */
-    public static String callRunProcedure(JSONObject jo) {
+    public static String callRunProcedure(JSONObject jo) throws JSONException, IOException {
 
         HttpClient httpClient = new DefaultHttpClient();
         JSONObject result = null;
@@ -1164,22 +1130,14 @@ public class OpenStackProvisionTest {
             httpPostRequest.setEntity(input);
             HttpResponse httpResponse = httpClient.execute(httpPostRequest);
 
-            result = new JSONObject(EntityUtils.toString(httpResponse.getEntity()));
-        } catch (Exception e) {
-            e.printStackTrace();
+            String responseStr = EntityUtils.toString(httpResponse.getEntity());
+            result = new JSONObject(responseStr);
+            assertTrue("jobId not found in the response: " + responseStr, result.has("jobId"));
+            return result.getString("jobId");
+
         } finally {
             httpClient.getConnectionManager().shutdown();
         }
-
-        if (result != null) {
-            try {
-                return result.getString("jobId");
-            } catch (JSONException e) {
-                e.printStackTrace();
-            }
-        }
-
-        return "";
 
     }
 
@@ -1233,29 +1191,37 @@ public class OpenStackProvisionTest {
     }
 
     /**
-     * waitForJob: Waits for job to be completed and reports outcome
+     * Waits for job to complete successfully
      *
-     * @param jobId
-     * @return outcome of job
+     * @param jobId id of the job being monitored
      */
-    public static String waitForJob(String jobId) throws IOException, JSONException {
+    public static void waitForJobToCompleteSuccessfully(String jobId) throws IOException, JSONException {
+
+        JSONObject result = waitForJobResult(jobId);
+        assertThat("Job outcome not found in " + result.toString(), result.has("outcome"), is(true));
+        assertThat("Job outcome not successful. Job details are: " + result.toString(),
+                result.getString("outcome"), is("success"));
+    }
+
+    /**
+     * Waits for job to be completed. Does not care for the
+     * outcome of the job.
+     * @param jobId id of the job being monitored
+     */
+    public static JSONObject waitForJobResult(String jobId) throws IOException, JSONException {
 
         String url = "http://" + COMMANDER_USER + ":" + COMMANDER_PASSWORD +
                 "@" + COMMANDER_SERVER + ":8000/rest/v1.0/jobs/" +
                 jobId + "?request=getJobStatus";
         JSONObject jsonObject = performHTTPGet(url);
 
-        try {
-            while (!jsonObject.getString("status").equalsIgnoreCase("completed")) {
-                jsonObject = performHTTPGet(url);
-            }
-
-            return jsonObject.getString("outcome");
-        } catch (JSONException e) {
-            e.printStackTrace();
+        // We are relying on the commander server to abort the job so
+        // looping without any checks against not ever reaching 'completed' state.
+        while (!jsonObject.getString("status").equalsIgnoreCase("completed")) {
+            jsonObject = performHTTPGet(url);
         }
 
-        return "";
+        return jsonObject;
 
     }
 
@@ -1305,7 +1271,7 @@ public class OpenStackProvisionTest {
         jobId = callRunProcedure(jo);
 
         // Block on job completion
-        waitForJob(jobId);
+        waitForJobResult(jobId);
         // Do not check job status. Delete will error if it does not exist
         // which is OK since that is the expected state.
     }
@@ -1315,7 +1281,6 @@ public class OpenStackProvisionTest {
      */
     private static void createConfiguration() throws JSONException, IOException {
 
-        String response = "";
         JSONObject parentJSONObject = new JSONObject();
         JSONArray actualParameterArray = new JSONArray();
 
@@ -1355,10 +1320,6 @@ public class OpenStackProvisionTest {
                 .put("value", "local"));
 
         actualParameterArray.put(new JSONObject()
-                .put("actualParameterName", "workspace")
-                .put("value", "default"));
-
-        actualParameterArray.put(new JSONObject()
                 .put("actualParameterName", "blockstorage_service_url")
                 .put("value", prop.getProperty(BLOCKSTORAGE_SERVICE_URL)));
 
@@ -1378,6 +1339,10 @@ public class OpenStackProvisionTest {
                 .put("actualParameterName", "orchestration_service_url")
                 .put("value", prop.getProperty(ORCHESTRATION_SERVICE_URL)));
 
+        actualParameterArray.put(new JSONObject()
+                .put("actualParameterName", PARAM_TENANTID)
+                .put("value", TENANTID));
+
         parentJSONObject.put("actualParameter", actualParameterArray);
 
         JSONArray credentialArray = new JSONArray();
@@ -1391,10 +1356,8 @@ public class OpenStackProvisionTest {
 
         String jobId = callRunProcedure(parentJSONObject);
 
-        response = waitForJob(jobId);
+        waitForJobToCompleteSuccessfully(jobId);
 
-        // Check job status
-        assertEquals("Job completed without errors", "success", response);
     }
     /**
      * Load the properties file


### PR DESCRIPTION
Added a validation script for CreateConfiguration to be used with
ValidateFormalParameters API by Dynamic Environments.

o Added createConfiguration.groovy script that will be used by the
ValidateFormalParameters API in order to validate the
CreateConfiguration parameters.
o Added optional tenantId parameter to CreateConfiguration. It is
required to validate the service end-point URLs since the service
catalog is associated with the tenant/project.
o Updated the createConfigForm.xml to mark the following parameters for
server-side validation. This information is used by the UI to trigger
the server-side call for the marked parameters:
- Identity URL
- Credential
- Tenant id
- Compute service URL
- Block service URL
- Image service URL
- Orchestration service URL
  o Updated build.gradle to support running groovy tests
