### PR TITLE
Added properties for credentials and configurations retrieval support

### DIFF
--- a/src/main/resources/project/manifest.xml
+++ b/src/main/resources/project/manifest.xml
@@ -236,38 +236,38 @@
     </file>
     <file>
         <path>procedures/form_scripts/validation/createConfiguration.groovy</path>
-        <xpath>//procedure[procedureName=&quot;CreateConfiguration&quot;]/propertySheet/property[propertyName=&quot;form&quot;]/propertySheet/property[propertyName=&quot;validation&quot;]/propertySheet/property[propertyName=&quot;script&quot;]/value</xpath>
+        <xpath>//procedure[procedureName=&quot;CreateConfiguration&quot;]/propertySheet/property[propertyName=&quot;ec_form&quot;]/propertySheet/property[propertyName=&quot;validation&quot;]/propertySheet/property[propertyName=&quot;script&quot;]/value</xpath>
     </file>
     <file>
         <path>procedures/form_scripts/parameterOptions/resources.groovy</path>
-        <xpath>//procedure[procedureName=&quot;CreateConfiguration&quot;]/propertySheet/property[propertyName=&quot;form&quot;]/propertySheet/property[propertyName=&quot;parameterOptions&quot;]/propertySheet/property[propertyName=&quot;resource&quot;]/value</xpath>
+        <xpath>//procedure[procedureName=&quot;CreateConfiguration&quot;]/propertySheet/property[propertyName=&quot;ec_form&quot;]/propertySheet/property[propertyName=&quot;parameterOptions&quot;]/propertySheet/property[propertyName=&quot;resource&quot;]/value</xpath>
     </file>
     <file>
         <path>procedures/form_scripts/parameterOptions/tenantId.groovy</path>
-        <xpath>//procedure[procedureName=&quot;_DeployDE&quot;]/propertySheet/property[propertyName=&quot;form&quot;]/propertySheet/property[propertyName=&quot;parameterOptions&quot;]/propertySheet/property[propertyName=&quot;tenant_id&quot;]/value</xpath>
+        <xpath>//procedure[procedureName=&quot;_DeployDE&quot;]/propertySheet/property[propertyName=&quot;ec_form&quot;]/propertySheet/property[propertyName=&quot;parameterOptions&quot;]/propertySheet/property[propertyName=&quot;tenant_id&quot;]/value</xpath>
     </file>
     <file>
         <path>procedures/form_scripts/parameterOptions/openStackOptions.groovy</path>
-        <xpath>//procedure[procedureName=&quot;_DeployDE&quot;]/propertySheet/property[propertyName=&quot;form&quot;]/propertySheet/property[propertyName=&quot;parameterOptions&quot;]/propertySheet/property[propertyName=&quot;image&quot;]/value</xpath>
+        <xpath>//procedure[procedureName=&quot;_DeployDE&quot;]/propertySheet/property[propertyName=&quot;ec_form&quot;]/propertySheet/property[propertyName=&quot;parameterOptions&quot;]/propertySheet/property[propertyName=&quot;image&quot;]/value</xpath>
     </file>
     <file>
         <path>procedures/form_scripts/parameterOptions/openStackOptions.groovy</path>
-        <xpath>//procedure[procedureName=&quot;_DeployDE&quot;]/propertySheet/property[propertyName=&quot;form&quot;]/propertySheet/property[propertyName=&quot;parameterOptions&quot;]/propertySheet/property[propertyName=&quot;flavor&quot;]/value</xpath>
+        <xpath>//procedure[procedureName=&quot;_DeployDE&quot;]/propertySheet/property[propertyName=&quot;ec_form&quot;]/propertySheet/property[propertyName=&quot;parameterOptions&quot;]/propertySheet/property[propertyName=&quot;flavor&quot;]/value</xpath>
     </file>
     <file>
         <path>procedures/form_scripts/parameterOptions/openStackOptions.groovy</path>
-        <xpath>//procedure[procedureName=&quot;_DeployDE&quot;]/propertySheet/property[propertyName=&quot;form&quot;]/propertySheet/property[propertyName=&quot;parameterOptions&quot;]/propertySheet/property[propertyName=&quot;keyPairName&quot;]/value</xpath>
+        <xpath>//procedure[procedureName=&quot;_DeployDE&quot;]/propertySheet/property[propertyName=&quot;ec_form&quot;]/propertySheet/property[propertyName=&quot;parameterOptions&quot;]/propertySheet/property[propertyName=&quot;keyPairName&quot;]/value</xpath>
     </file>
     <file>
         <path>procedures/form_scripts/parameterOptions/openStackOptions.groovy</path>
-        <xpath>//procedure[procedureName=&quot;_DeployDE&quot;]/propertySheet/property[propertyName=&quot;form&quot;]/propertySheet/property[propertyName=&quot;parameterOptions&quot;]/propertySheet/property[propertyName=&quot;availability_zone&quot;]/value</xpath>
+        <xpath>//procedure[procedureName=&quot;_DeployDE&quot;]/propertySheet/property[propertyName=&quot;ec_form&quot;]/propertySheet/property[propertyName=&quot;parameterOptions&quot;]/propertySheet/property[propertyName=&quot;availability_zone&quot;]/value</xpath>
     </file>
     <file>
         <path>procedures/form_scripts/parameterOptions/openStackOptions.groovy</path>
-        <xpath>//procedure[procedureName=&quot;_DeployDE&quot;]/propertySheet/property[propertyName=&quot;form&quot;]/propertySheet/property[propertyName=&quot;parameterOptions&quot;]/propertySheet/property[propertyName=&quot;security_groups&quot;]/value</xpath>
+        <xpath>//procedure[procedureName=&quot;_DeployDE&quot;]/propertySheet/property[propertyName=&quot;ec_form&quot;]/propertySheet/property[propertyName=&quot;parameterOptions&quot;]/propertySheet/property[propertyName=&quot;security_groups&quot;]/value</xpath>
     </file>
     <file>
         <path>procedures/form_scripts/parameterOptions/workspaces.groovy</path>
-        <xpath>//procedure[procedureName=&quot;_DeployDE&quot;]/propertySheet/property[propertyName=&quot;form&quot;]/propertySheet/property[propertyName=&quot;parameterOptions&quot;]/propertySheet/property[propertyName=&quot;resource_workspace&quot;]/value</xpath>
+        <xpath>//procedure[procedureName=&quot;_DeployDE&quot;]/propertySheet/property[propertyName=&quot;ec_form&quot;]/propertySheet/property[propertyName=&quot;parameterOptions&quot;]/propertySheet/property[propertyName=&quot;resource_workspace&quot;]/value</xpath>
     </file>
 </fileset>

--- a/src/main/resources/project/procedures/form_scripts/parameterOptions/openStackOptions.groovy
+++ b/src/main/resources/project/procedures/form_scripts/parameterOptions/openStackOptions.groovy
@@ -40,10 +40,6 @@ final String IMAGE_SERVICE_URL = "image_service_url"
 final String IMAGE_API_VERSION = "image_api_version"
 
 @Field
-final String CONFIGURATION_NAME_FROM_CONFIG = "config"
-@Field
-final String CONFIGURATION_NAME = "connection_config"
-@Field
 final String TENANT_ID = "tenant_id"
 
 def result = new FormalParameterOptionsResult()
@@ -70,9 +66,6 @@ boolean canGetOptions(args) {
             args.configurationParameters[IDENTITY_SERVICE_URL] &&
             args.configurationParameters[IDENTITY_API_VERSION] &&
             args.parameters[TENANT_ID] &&
-            args.parameters[CONFIGURATION_NAME] &&
-            args.configurationParameters[CONFIGURATION_NAME_FROM_CONFIG] &&
-            args.parameters[CONFIGURATION_NAME] == args.configurationParameters[CONFIGURATION_NAME_FROM_CONFIG] &&
             canGetOptionsForParameter(args, args.formalParameterName)
 
 }

--- a/src/main/resources/project/procedures/form_scripts/parameterOptions/tenantId.groovy
+++ b/src/main/resources/project/procedures/form_scripts/parameterOptions/tenantId.groovy
@@ -12,10 +12,15 @@ final String TENANT_ID_FROM_CONFIG = "tenant_id"
 
 def result = new FormalParameterOptionsResult()
 
-// If configs are the same, use the config tenant_id if set
+// If configs are the same,
+// Or if using the passed in config (in which case, the configurationParameters does not have the config name)
+// Then use the config tenant_id if set
 if (args?.parameters &&
         args.parameters[CONFIGURATION_NAME] &&
-        args.parameters[CONFIGURATION_NAME] == args.configurationParameters[CONFIGURATION_NAME_FROM_CONFIG]) {
+        args.configurationParameters &&
+        (args.parameters[CONFIGURATION_NAME] == args.configurationParameters[CONFIGURATION_NAME_FROM_CONFIG] ||
+            !args.configurationParameters[CONFIGURATION_NAME_FROM_CONFIG])
+    ) {
 
     if (args.configurationParameters[TENANT_ID_FROM_CONFIG]) {
         result.add(args.configurationParameters[TENANT_ID_FROM_CONFIG], args.configurationParameters[TENANT_ID_FROM_CONFIG])

--- a/src/main/resources/project/project.xml
+++ b/src/main/resources/project/project.xml
@@ -214,6 +214,12 @@
                     </property>
                 </propertySheet>
             </property>
+            <!--Property used to specify the location path for the plugin configurations-->
+            <property>
+                <propertyName>ec_configurations</propertyName>
+                <expandable>1</expandable>
+                <value>openstack_cfgs</value>
+            </property>
             <property>
                 <propertyName>plugin_driver</propertyName>
                 <description>Home for perl code</description>
@@ -462,7 +468,7 @@
                 </property>
                 <!--Form scripts for validation and dynamic options-->
                 <property>
-                    <propertyName>form</propertyName>
+                    <propertyName>ec_form</propertyName>
                     <propertySheet>
                         <property>
                             <propertyName>validation</propertyName>
@@ -1289,7 +1295,7 @@
                 </property>
                 <!--Form scripts for validation and dynamic options-->
                 <property>
-                    <propertyName>form</propertyName>
+                    <propertyName>ec_form</propertyName>
                     <propertySheet>
                         <property>
                             <propertyName>parameterOptions</propertyName>
@@ -1330,6 +1336,16 @@
                                     <value/>
                                 </property>
                             </propertySheet>
+                        </property>
+                        <property>
+                            <propertyName>configurationParameterRef</propertyName>
+                            <expandable>1</expandable>
+                            <value>connection_config</value>
+                        </property>
+                        <property>
+                            <propertyName>usesConfigurationNameAsCredential</propertyName>
+                            <expandable>1</expandable>
+                            <value>1</value>
                         </property>
                     </propertySheet>
                 </property>

--- a/src/test/groovy/ecplugins/openstack/OpenStackOptionsRetrievalTest.groovy
+++ b/src/test/groovy/ecplugins/openstack/OpenStackOptionsRetrievalTest.groovy
@@ -70,8 +70,7 @@ class OpenStackOptionsRetrievalTest extends BaseScriptsTestCase {
 
         def configurationParams = json (
                 identity_service_url : testProperties.getString(PROP_IDENTITY_SVC_URL),
-                keystone_api_version: testProperties.getString(PROP_IDENTITY_SVC_VERSION),
-                config:'test',
+                keystone_api_version: testProperties.getString(PROP_IDENTITY_SVC_VERSION)
         )
 
         //merge configurationParams with the inputConfigurationParams


### PR DESCRIPTION
Added following properties for credentials and configurations retrieval
support for the formal parameter APIs.

1) ec_form/configurationParameterRef: Procedure property for the formal
parameter name in the procedure that refers to the plugin configuration
that the procedure uses. For _DeployDE procedure, this property is set
to 'connection_config'.
2) ec_form/usesConfigurationNameAsCredential: Procedure property for
whether the configuration name (referred to in the previous property)
should be used to retrieve the attached credential for the procedure.
For _DeployDE procedure, this property is set to '1' so that the
attached credential can be retrieved using the value set in the
'config_connection' parameter.
3) ec_configurations: Plugin project property for the path where the
configurations are stored relative to the project. For EC-OpenStack
plugin, this property is set to 'openstack_cfgs'.

Also renamed the 'form/validation' and 'form/parameterOptions' property
sheets to 'ec_form/validation' and 'ec_form/parameterOptions'
respectively.
