### PR TITLE
Mark validation and parameter options property sheets as credential p…

### DIFF
--- a/src/main/resources/project/project.xml
+++ b/src/main/resources/project/project.xml
@@ -473,6 +473,8 @@
                         <property>
                             <propertyName>validation</propertyName>
                             <propertySheet>
+                                <!--Flag the property sheet as being protected by credentials attached to the enclosing procedure's steps.-->
+                                <credentialProtected>1</credentialProtected>
                                 <property>
                                     <propertyName>script</propertyName>
                                     <expandable>1</expandable>
@@ -483,6 +485,8 @@
                         <property>
                             <propertyName>parameterOptions</propertyName>
                             <propertySheet>
+                                <!--Flag the property sheet as being protected by credentials attached to the enclosing procedure's steps.-->
+                                <credentialProtected>1</credentialProtected>
                                 <property>
                                     <propertyName>resource</propertyName>
                                     <expandable>1</expandable>
@@ -1300,6 +1304,8 @@
                         <property>
                             <propertyName>parameterOptions</propertyName>
                             <propertySheet>
+                                <!--Flag the property sheet as being protected by credentials attached to the enclosing procedure's steps.-->
+                                <credentialProtected>1</credentialProtected>
                                 <property>
                                     <propertyName>tenant_id</propertyName>
                                     <expandable>1</expandable>


### PR DESCRIPTION
…rotected.

Mark the property sheets for validation and parameter options as being
protected by credentials attached to the enclosing procedure's steps.
- parameterOptions
- validation
