### PR TITLE
Move credentials to the top when displaying configuration parameters …

### DIFF
--- a/src/main/resources/project/ui_forms/createConfigForm.xml
+++ b/src/main/resources/project/ui_forms/createConfigForm.xml
@@ -15,6 +15,14 @@
         <documentation>Provide a simple description for this configuration.</documentation>
     </formElement>
     <formElement>
+        <type>credential</type>
+        <label>Login as:</label>
+        <property>credential</property>
+        <required>1</required>
+        <serverValidation>1</serverValidation>
+        <documentation>OpenStack account username/password. This account must have enough privileges to perform API functions.</documentation>
+    </formElement>
+    <formElement>
         <type>entry</type>
         <label>Identity Service URL:</label>
         <property>identity_service_url</property>
@@ -39,14 +47,6 @@
             <name>3</name>
             <value>3</value>
         </option>
-    </formElement>
-    <formElement>
-        <type>credential</type>
-        <label>Login as:</label>
-        <property>credential</property>
-        <required>1</required>
-        <serverValidation>1</serverValidation>
-        <documentation>OpenStack account username/password. This account must have enough privileges to perform API functions.</documentation>
     </formElement>
     <formElement>
         <label>Tenant ID:</label>


### PR DESCRIPTION
…for dynamic envts

CEV9126 - This allows the credentials to be displayed right before the
service URL allowing the user to view the authentication-specific
parameters together on the screen.
