### PR TITLE
Updated openStackOptions.groovy script to retrieve the complete image list

### DIFF
--- a/src/main/resources/project/procedures/form_scripts/parameterOptions/openStackOptions.groovy
+++ b/src/main/resources/project/procedures/form_scripts/parameterOptions/openStackOptions.groovy
@@ -38,10 +38,6 @@ final String IDENTITY_API_VERSION = "keystone_api_version"
 final String COMPUTE_SERVICE_URL = "compute_service_url"
 @Field
 final String COMPUTE_SERVICE_VERSION = "api_version"
-@Field
-final String IMAGE_SERVICE_URL = "image_service_url"
-@Field
-final String IMAGE_API_VERSION = "image_api_version"
 
 @Field
 final String TENANT_ID = "tenant_id"
@@ -81,23 +77,8 @@ boolean canGetOptions(args) {
 }
 
 boolean canGetOptionsForParameter(args, formalParameterName) {
-    switch (formalParameterName) {
-        case 'flavor':
-            return args.configurationParameters[COMPUTE_SERVICE_URL] &&
-                    args.configurationParameters[COMPUTE_SERVICE_VERSION]
-        case 'availability_zone':
-            return args.configurationParameters[COMPUTE_SERVICE_URL]&&
-                    args.configurationParameters[COMPUTE_SERVICE_VERSION]
-        case 'security_groups':
-            return args.configurationParameters[COMPUTE_SERVICE_URL]&&
-                    args.configurationParameters[COMPUTE_SERVICE_VERSION]
-        case 'keyPairName':
-            return args.configurationParameters[COMPUTE_SERVICE_URL]&&
-                    args.configurationParameters[COMPUTE_SERVICE_VERSION]
-        case 'image':
-            return args.configurationParameters[IMAGE_SERVICE_URL] &&
-                    args.configurationParameters[IMAGE_API_VERSION]
-    }
+    return args.configurationParameters[COMPUTE_SERVICE_URL]&&
+            args.configurationParameters[COMPUTE_SERVICE_VERSION]
 }
 
 List getOptions(args, authToken) {
@@ -211,10 +192,6 @@ String buildServiceURL(args) {
     def computeServiceVersion = args.configurationParameters[COMPUTE_SERVICE_VERSION]
 
     //
-    def imageServiceUrl = args.configurationParameters[IMAGE_SERVICE_URL]
-    def imageServiceVersion = args.configurationParameters[IMAGE_API_VERSION]
-
-    //
     def tenantId = args.configurationParameters[TENANT_ID]
 
     switch (args.formalParameterName) {
@@ -229,10 +206,9 @@ String buildServiceURL(args) {
 
         case 'keyPairName':
             return "$computeServiceUrl/v${computeServiceVersion}/$tenantId/os-keypairs"
+
         case 'image':
-            return imageServiceVersion == '1' ?
-                    "$imageServiceUrl/v${imageServiceVersion}/images/detail?status=active":
-                    "$imageServiceUrl/v${imageServiceVersion}/images?status=active"
+            return "$computeServiceUrl/v${computeServiceVersion}/$tenantId/images?status=active"
 
     }
 

--- a/src/main/resources/project/procedures/form_scripts/validation/createConfiguration.groovy
+++ b/src/main/resources/project/procedures/form_scripts/validation/createConfiguration.groovy
@@ -85,7 +85,7 @@ if (canValidate(args)) {
 
     // The current context class loader is the one which
     // loaded the DslDelegate class, which is the application's
-    // class loader. That is not the class loader we can to use
+    // class loader. That is not the class loader we want to use
     // to find the services registered in the external libraries.
     // So we save the contextClassLoader before switching the context
     // class loader on the thread to the Groovy class loader which is

--- a/src/test/groovy/ecplugins/openstack/OpenStackOptionsRetrievalTest.groovy
+++ b/src/test/groovy/ecplugins/openstack/OpenStackOptionsRetrievalTest.groovy
@@ -6,13 +6,13 @@ import groovy.json.JsonOutput
 class OpenStackOptionsRetrievalTest extends BaseScriptsTestCase {
 
 
-    void testImagesOptionsRetrievalV1() {
+    void testImagesOptionsRetrieval() {
 
         def json = new JsonBuilder()
 
         def imageParams = json (
-                image_service_url: testProperties.getString(PROP_IMAGE_SVC_URL),
-                image_api_version: '1'
+                compute_service_url: testProperties.getString(PROP_COMPUTE_SVC_URL),
+                api_version: '2'
         )
 
         def inputParams = createScriptInputParams(imageParams, 'image')
@@ -68,12 +68,12 @@ class OpenStackOptionsRetrievalTest extends BaseScriptsTestCase {
 
         def actualParams = json (
                 connection_config:'test',
-                tenant_id: TENANT_ID
         )
 
         def configurationParams = json (
                 identity_service_url : testProperties.getString(PROP_IDENTITY_SVC_URL),
-                keystone_api_version: testProperties.getString(PROP_IDENTITY_SVC_VERSION)
+                keystone_api_version: testProperties.getString(PROP_IDENTITY_SVC_VERSION),
+                tenant_id: TENANT_ID
         )
 
         //merge configurationParams with the inputConfigurationParams


### PR DESCRIPTION
o Switched to compute API for image list retrieval
- provides a complete image list by default
- the images are available for use with the compute service for
  provisioning VMs on OpenStack
