### PR TITLE
Added possibility to disable IP assotiation during DE configuration.

### DIFF
--- a/src/main/resources/project/OpenStack.pm
+++ b/src/main/resources/project/OpenStack.pm
@@ -505,11 +505,19 @@ None.
 sub deploy {
     my ($self) = @_;
 
-    my $vm_prefix;
+    my $vm_prefix = '';
 
     # Set the prefix to resource pool name if one has been specified
     # For Dynamic environments, we expect a resource_pool to be provided but
     # no server_name
+
+    $self->debug_msg(1, "Deploy options:\n");
+    my $opts = $self->opts();
+    for my $k (keys %$opts) {
+        $self->debug_msg(1, "$k: $opts->{$k}");
+    }
+    $self->debug_msg(1, "\n\n");
+
     if ($self->opts->{resource_pool}) {
          $vm_prefix = $self->opts->{resource_pool};
     } else {
@@ -756,7 +764,7 @@ sub deploy_vm {
 
     my $resource = $EMPTY;
 
-    if ( $self->opts->{associate_ip} ) {
+    if ($self->opts->{associate_ip}) {
         $self->debug_msg( 1, "Allocating ip to instance: $tenant_url" );
 
         my $allocated_ips_ref = $self->get_allocated_ips($tenant_url);
@@ -3180,10 +3188,6 @@ None.
 
 sub make_new_resource {
     my ( $self, $res_name, $server, $host, $additional_opts) = @_;
-    print "Res_name: ", Dumper $res_name;
-    print "Server: ", Dumper $server;
-    print "Host: ", Dumper $host;
-    print "Additional opts: ", Dumper $additional_opts;
 
     my $pool = $self->opts->{resource_pool};
 
@@ -3490,7 +3494,7 @@ sub associate_ip_to_instance {
     );
 
     if ( $self->opts->{exitcode} && $self->opts->{restcode} ) {
-        print "IP $ip was successfully deployed to instance\n";
+        $self->debug_msg(1, "IP $ip was successfully deployed to instance\n");
         return 0;
     }
 

--- a/src/main/resources/project/procedures/deploy_DE.pl
+++ b/src/main/resources/project/procedures/deploy_DE.pl
@@ -53,6 +53,13 @@ $opts->{customization_script} = q{$[customization_script]};
 # Results location: property path to store server information.
 $opts->{location} = q{$[location]};
 
+# IP association and allocation trigger
+$opts->{associate_ip} = q{$[associate_ip]};
+
+# server name as name base for DE servers
+
+$opts->{server_name} = 'EC_dyn';
+
 #
 # '_DeployDE' deviations from the 'Deploy' procedure being made
 # for dynamic environments feature.
@@ -65,9 +72,6 @@ if ($opts->{resource_pool}) {
     # Create Resource if resource pool name was assigned
     $opts->{resource_check} = 1;
 }
-
-# Always associate IP to the deployed instances
-$opts->{associate_ip} = 1;
 
 # Deploy tag to identify this deployment in the resource location, default to jobStepId.
 $opts->{tag} = q{$[jobStepId]};

--- a/src/main/resources/project/project.xml
+++ b/src/main/resources/project/project.xml
@@ -952,7 +952,7 @@
                                         <property>
                                             <propertyName>initiallyChecked</propertyName>
                                             <expandable>1</expandable>
-                                            <value>0</value>
+                                            <value>1</value>
                                         </property>
                                         <property>
                                             <propertyName>uncheckedValue</propertyName>
@@ -1305,6 +1305,31 @@
                                         </property>
                                     </propertySheet>
                                 </property>
+                                <property>
+                                    <propertyName>associate_ip</propertyName>
+                                    <propertySheet>
+                                        <property>
+                                            <propertyName>checkedValue</propertyName>
+                                            <expandable>1</expandable>
+                                            <value>1</value>
+                                        </property>
+                                        <property>
+                                            <propertyName>formType</propertyName>
+                                            <expandable>1</expandable>
+                                            <value>standard</value>
+                                        </property>
+                                        <property>
+                                            <propertyName>initiallyChecked</propertyName>
+                                            <expandable>1</expandable>
+                                            <value>0</value>
+                                        </property>
+                                        <property>
+                                            <propertyName>uncheckedValue</propertyName>
+                                            <expandable>1</expandable>
+                                            <value>0</value>
+                                        </property>
+                                    </propertySheet>
+                                </property>
                             </propertySheet>
                         </property>
                     </propertySheet>
@@ -1489,6 +1514,15 @@
                 <required>0</required>
                 <type>entry</type>
             </formalParameter>
+
+            <formalParameter>
+                <formalParameterName>associate_ip</formalParameterName>
+                <defaultValue/>
+                <description/>
+                <required>0</required>
+                <type>entry</type>
+            </formalParameter>
+            
             <step>
                 <stepName>_DeployDE</stepName>
                 <alwaysRun>0</alwaysRun>

--- a/src/main/resources/project/ui_forms/deploy_DE.xml
+++ b/src/main/resources/project/ui_forms/deploy_DE.xml
@@ -100,7 +100,7 @@
         <label>Associate IP?:</label>
         <property>associate_ip</property>
         <value/>
-        <documentation>Associate IP to deployed instance?:</documentation>
+        <documentation>Associate IP to deployed instance? Must be unchecked for the RackSpace because RackSpace automatically assigns IP to the instance.</documentation>
         <required>0</required>
         <type>checkbox</type>
         <initiallyChecked>1</initiallyChecked>

--- a/src/main/resources/project/ui_forms/deploy_DE.xml
+++ b/src/main/resources/project/ui_forms/deploy_DE.xml
@@ -97,6 +97,17 @@
         <dependsOn>connection_config</dependsOn>
     </formElement>
     <formElement>
+        <label>Associate IP?:</label>
+        <property>associate_ip</property>
+        <value/>
+        <documentation>Associate IP to deployed instance?:</documentation>
+        <required>0</required>
+        <type>checkbox</type>
+        <initiallyChecked>1</initiallyChecked>
+        <checkedValue>1</checkedValue>
+        <uncheckedValue>0</uncheckedValue>
+    </formElement>
+    <formElement>
         <label>Customization script:</label>
         <property>customization_script</property>
         <value/>


### PR DESCRIPTION
Added possibility to disable IP assotiation during DE configuration and, also, fixed 1 warning. For dynamic environments, if server name is not specified, EC_dyn prefix will be used for those server/servers.